### PR TITLE
Frontend: Add capsule details page

### DIFF
--- a/frontend/src/components/CapsuleDetailCard.css
+++ b/frontend/src/components/CapsuleDetailCard.css
@@ -1,0 +1,41 @@
+.capsule-detail-card {
+  margin-top: 20px;
+}
+
+.section-header {
+  font-size: 20px;
+  font-weight: bold;
+  margin: 20px 0 10px;
+}
+
+.photos-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 8px; 
+}
+
+.photo {
+  width: 100%;
+  height: 200px; 
+  width: 200px;
+  border-radius: 6px; 
+  object-fit: cover;
+}
+
+.messages-container {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+
+.capsule-message {
+    background-color: #a08394;
+    padding: 30px;
+    border-radius: 16px;
+    font-size: 18px;
+    line-height: 1.8;
+    color: #fff;
+    max-width: 400px; 
+    width: 140px; 
+}

--- a/frontend/src/components/CapsuleDetailCard.jsx
+++ b/frontend/src/components/CapsuleDetailCard.jsx
@@ -1,58 +1,39 @@
-/**
- * CapsuleDetailsCard Component
- * Combines media and CapsuleCardImage functionality from CapsuleCard.
- */
-
-import { useNavigate } from "react-router-dom";
-import { formatDateTime } from "../utils/date";
-import { CapsuleCardImage } from "../ui/CapsuleCardImage";
+import "./CapsuleDetailCard.css";
 
 export const CapsuleDetailCard = ({ capsule }) => {
   const {
-    id,
     title,
     message,
     mediaUrls = [],
-    createdAt = null,
-    openAt = null,
     recipients = [],
   } = capsule.data || {};
 
-  console.log("Recipients data:", recipients);
-  console.log("Created At:", createdAt);
-  console.log("Open At:", openAt);
-
-  const navigateToCapsule = useNavigate();
-
-  const handleViewCapsule = () => {
-    navigateToCapsule(`/capsules/${id}`);
-  };
-
-  const isCapsuleOpen = openAt ? new Date() >= new Date(openAt) : false;
-  const formattedCreatedAt = createdAt
-    ? formatDateTime(new Date(createdAt), "yyyy-MM-dd HH:mm")
-    : "Invalid date";
-  const formattedOpenAt = openAt
-    ? formatDateTime(new Date(openAt), "yyyy-MM-dd HH:mm")
-    : "Invalid date";
-
   return (
-    <div className="capsule-detail-card" onClick={handleViewCapsule}>
-      <CapsuleCardImage mediaUrls={mediaUrls} isBlurred={!isCapsuleOpen} />
-      <h5>Title: {title}</h5>
-      <p>Message: {message}</p>
-      <p>Recipients:</p>
-      <ul>
-        {Array.isArray(recipients) && recipients.length > 0 ? (
-          recipients.map((recipient) => (
-            <li key={recipient._id}>{recipient.username}</li>
+    <div className="capsule-detail-card">
+      <h2 className="section-header">Photos</h2>
+      <div className="photos-container">
+        {mediaUrls.length > 0 ? (
+          mediaUrls.map((url, index) => (
+            <img
+              key={index}
+              src={url}
+              alt={`Capsule Photo ${index + 1}`}
+              className="photo"
+            />
           ))
         ) : (
-          <li>No recipients available</li>
+          <p>No photos available</p>
         )}
-      </ul>
-      <p>Created: {formattedCreatedAt}</p>
-      <p>Unlocks on: {formattedOpenAt}</p>
+      </div>
+
+      <h2 className="section-header">Messages</h2>
+      <div className="messages-container">
+        {message ? (
+          <div className="capsule-message">{message}</div>
+        ) : (
+          <p>No messages available</p>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/CapsuleDetailsPage.css
+++ b/frontend/src/pages/CapsuleDetailsPage.css
@@ -1,0 +1,31 @@
+.capsule-details-page {
+  padding: 20px;
+  position: relative;
+}
+
+.back-button {
+  position: absolute;
+  top: 60px;
+  left: 20px;
+  cursor: pointer;
+}
+
+.title-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+  text-align: center;
+}
+
+.capsule-title {
+  font-size: 24px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.capsule-unlock-date {
+  font-size: 16px;
+  font-weight: normal;
+  margin-top: 5px;
+}

--- a/frontend/src/pages/CapsuleDetailsPage.jsx
+++ b/frontend/src/pages/CapsuleDetailsPage.jsx
@@ -1,91 +1,69 @@
-/**
- * This page is for view an individual capsule.
- */
-import useStore from "../store/store";
 import { useState, useEffect } from "react";
 import { useParams, Navigate, useNavigate } from "react-router-dom";
-import { SideMenu } from "../components/SideMenu";
+import useStore from "../store/store";
 import { Header } from "../components/Header";
-import { formatDateTime } from "../utils/date";
+import { SideMenu } from "../components/SideMenu";
+import { ArrowLeftIcon } from "../ui/ArrowLeftIcon";
 import { CapsuleDetailCard } from "../components/CapsuleDetailCard";
+import "./CapsuleDetailsPage.css";
 
 export const CapsuleDetailsPage = () => {
   const user = useStore((state) => state.user);
-  const logout = useStore((state) => state.logout);
   const navigate = useNavigate();
-  const [showMenu, setShowMenu] = useState(false);
-  const { id } = useParams(); // Get the capsule ID from the URL
-  console.log("Capsule ID from URL:", id);
+  const { id } = useParams();
 
-  const getCapsuleById = useStore((state) => state.getCapsuleById); // Get the method to fetch a capsule by ID
-  const [capsuleDetails, setCapsuleDetails] = useState(null); // Store the capsule in the local state
-  const [loading, setLoading] = useState(true); // Track loading state
+  const getCapsuleById = useStore((state) => state.getCapsuleById);
+  const [capsuleDetails, setCapsuleDetails] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Fetch the capsule details when the component mounts
-    console.log("Frontend: Fetching capsule for ID:", id);
-
     const fetchCapsule = async () => {
       try {
         const capsule = await getCapsuleById(id);
-        console.log("Frontend: Fetched capsule:", capsule);
         setCapsuleDetails(capsule);
       } catch (error) {
-        console.error("Frontend: Error fetching capsule details:", error);
+        console.error("Error fetching capsule details:", error);
       } finally {
         setLoading(false);
       }
     };
 
-    if (id) {
-      fetchCapsule();
-    } else {
-      console.log("Frontend: No ID provided for fetching capsule.");
-      setLoading(false);
-    }
+    if (id) fetchCapsule();
+    else setLoading(false);
   }, [id, getCapsuleById]);
 
   if (!user) {
     return <Navigate to="/login" replace />;
   }
 
-  const handleLogout = () => {
-    logout(); // Call the logout method from your store
-    navigate("/"); // Redirect to home or login page
-  };
-
-  // Handle loading state
   if (loading) {
     return <p>Loading capsule details...</p>;
   }
 
-  // Handle capsule not found
   if (!capsuleDetails) {
     return <p>Capsule not found.</p>;
   }
 
-  // Check if the capsule is locked
-  const isLocked = new Date() < new Date(capsuleDetails.openAt);
+  const { title, openAt } = capsuleDetails.data;
 
   return (
     <>
-      <Header toggleMenu={() => setShowMenu(!showMenu)} />
-      <SideMenu
-        showMenu={showMenu}
-        toggleMenu={() => setShowMenu(false)}
-        isLoggedIn={!!user}
-        onLogoutClick={handleLogout}
-      />
-      <div>
-        <h1>Capsule Details Page</h1>
-        {isLocked ? (
-          <p>
-           This capsule is locked until{" "}
-           {formatDateTime(new Date(capsuleDetails.openAt))}.
-          </p>
-        ) : (
-          <CapsuleDetailCard capsule={capsuleDetails} />
-          )}
+      <Header />
+      <SideMenu />
+      <div className="capsule-details-page">
+        {/* Back Button */}
+        <div className="back-button" onClick={() => navigate(-1)}>
+          <ArrowLeftIcon />
+        </div>
+
+        {/* Title and Unlock Date */}
+        <div className="title-container">
+          <h1 className="capsule-title">{title || "Untitled Capsule"}</h1>
+          <p className="capsule-unlock-date">Unlocked {new Date(openAt).toLocaleDateString()}</p>
+        </div>
+
+        {/* Capsule Detail Card */}
+        <CapsuleDetailCard capsule={capsuleDetails} />
       </div>
     </>
   );


### PR DESCRIPTION
WHat has been done:

- CapsuleDetailsPage.jsx
  - The page fetches the capsule data and provides it as a prop to the CapsuleDetailCard
  - Displays the back arrow, title, and unlock date in a layout
  - Called and is passed the capsule data, including the message and photo URLs
- CapsuleDetailCard.jsx
  - Renders photos with the mediaUrls array, it displays each photo in the grid layout
  - Renders messages with the message property from the capsule data
- CSS Updates:
  - Adjusted the styling of photos to make them smaller and aligned with the grid layout
  - Styled the message container to have a specific width, improved padding, and proper centering
  - Added a unique class for messages to avoid conflicts