### PR TITLE
Feature - Add Warning to Play button

### DIFF
--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -1,45 +1,60 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { ClockIcon } from "../ui/ClockIcon";
 import { PlayButton } from "../ui/PlayButton";
 import { CapsuleCardImage } from "../ui/CapsuleCardImage";
-import { WarningPopup } from "./WarningPopup";
+import { WarningPopup } from "./WarningPopup"; 
 import useStore from "../store/store";
 import "./LatestLocket.css";
 import { useNavigate } from "react-router-dom";
 import { useCapsuleStatus } from "../hooks/useCapsuleStatus";
 
-
 export const LatestLocket = () => {
+  const [nextCapsule, setNextCapsule] = useState(null);
   const [showWarning, setShowWarning] = useState(false);
-  const [isRevealed, setIsRevealed] = useState(false);
-  const capsules = useStore((state) => state.capsules.created) || [];
+  const [isWaiting, setIsWaiting] = useState(false); 
+  const capsules = useStore((state) => state.capsules?.created) || [];
   const navigateToCapsule = useNavigate();
 
-  const nextCapsule = !isRevealed
-    ? capsules
-        .filter((capsule) => capsule?.openAt)
-        .sort((a, b) => new Date(a.openAt).getTime() - new Date(b.openAt).getTime())
-        .find((capsule) => new Date(capsule.openAt) > new Date()) || null
-    : null;
+  /**
+   * useMemo stores the filtered and sorted capsule list to avoid recalculations on every render.
+   * - Filters out only future capsules (openAt > now)
+   * - Sorts capsules in ascending order (soonest first)
+   */
+  const futureCapsules = useMemo(() => {
+    return capsules
+      .filter((locket) => locket?.openAt && new Date(locket.openAt) > new Date()) 
+      .sort((a, b) => new Date(a.openAt) - new Date(b.openAt)); 
+  }, [capsules]);
 
+  // Pick the next capsule to be opened (only if we are not in the 10-minute waiting)
+  useEffect(() => {
+    if (isWaiting || !futureCapsules.length) {
+      return;
+    }
+    setNextCapsule(futureCapsules[0]);
+  }, [futureCapsules, isWaiting]);
+
+  // Use countdown hook for timeLeft and isCapsuleOpen on nextCapsule
   const { capsuleId, isCapsuleOpen, timeLeft } = useCapsuleStatus(nextCapsule);
 
+  // When capsule is open, wait 10 minutes before showing the next one
   useEffect(() => {
-    if (!isCapsuleOpen || isRevealed) return;
+    if (!nextCapsule || !isCapsuleOpen) return;
 
-    // Stopps nextCapsule for 10 minutes
-    setIsRevealed(true);
-    const revealTimer = setTimeout(() => {
-      setIsRevealed(false);
-    }, 600000); // 10 minutes 
+    setIsWaiting(true);
+    const timer = setTimeout(() => {
+      setIsWaiting(false);
+    }, 600000); // 10 minutes
 
-    return () => clearTimeout(revealTimer);
-  }, [isCapsuleOpen, isRevealed]);
+    return () => clearTimeout(timer);
+  }, [nextCapsule, isCapsuleOpen]);
 
+  // Click Play button and verify that the capsule has an id and that there is a next capsule, otherwise nothing happens. 
   const handlePlayButtonClick = () => {
-    if (!capsuleId) return;
+    if (!capsuleId || !nextCapsule) return;
 
     if (isCapsuleOpen) {
+      // Navigate to the capsule
       navigateToCapsule(`/capsules/${capsuleId}`);
     } else {
       setShowWarning(true);
@@ -48,42 +63,50 @@ export const LatestLocket = () => {
 
   return (
     <>
-    <div className="latest-locket">
-      <div className="locket-content">
-        {nextCapsule ? (
-          <>
-            <p>Your latest locket is opening on</p>
-            <div className="locket-date">
-              <ClockIcon />
-              <span>{new Date(nextCapsule.openAt).toLocaleString()}</span>
-            </div>
-            <p className="countdown-text">Time left: {timeLeft}</p>
-          </>
-        ) : (
-          <p className="countdown-text">No upcoming capsules</p>
-        )}
-      </div>
-      <PlayButton onClick={handlePlayButtonClick} />
+      <div className="latest-locket">
+        <div className="locket-content">
+          {/* If there is a capsule to open */}
+          {nextCapsule ? (
+            <>
+              <p>Your latest locket is opening on</p>
+              <div className="locket-date">
+                <ClockIcon />
+                <span>{new Date(nextCapsule.openAt).toLocaleString()}</span>
+              </div>
+              <p className="countdown-text">{timeLeft}</p>
+            </>
+          ) : (
+            // No more lockets
+            <p className="countdown-text">No upcoming lockets</p>
+          )}
+        </div>
 
-      <div className="locket-images">
-        <CapsuleCardImage
-          mediaUrls={["https://via.placeholder.com/150"]}
-          isBlurred={false}
-          variant="tilted"
-        />
-        <CapsuleCardImage
-          mediaUrls={["https://via.placeholder.com/150"]}
-          isBlurred={false}
-          variant="tilted"
-        />
-        <CapsuleCardImage
-          mediaUrls={["https://via.placeholder.com/150"]}
-          isBlurred={false}
-          variant="tilted"
-        />
+        <PlayButton onClick={handlePlayButtonClick} />
+
+        <div className="locket-images">
+          <CapsuleCardImage
+            mediaUrls={["https://via.placeholder.com/150"]}
+            isBlurred={false}
+            variant="tilted"
+          />
+          <CapsuleCardImage
+            mediaUrls={["https://via.placeholder.com/150"]}
+            isBlurred={false}
+            variant="tilted"
+          />
+          <CapsuleCardImage
+            mediaUrls={["https://via.placeholder.com/150"]}
+            isBlurred={false}
+            variant="tilted"
+          />
+        </div>
       </div>
-    </div>
-    { showWarning && <WarningPopup onClose={() => setShowWarning(false)} /> }
-  </>
+
+      {/* Warning */}
+      {showWarning && (
+        <WarningPopup onClose={() => setShowWarning(false)} />
+      )}
+    </>
   );
 };
+

--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -8,17 +8,33 @@ import "./LatestLocket.css";
 import { useNavigate } from "react-router-dom";
 import { useCapsuleStatus } from "../hooks/useCapsuleStatus";
 
+
 export const LatestLocket = () => {
   const [showWarning, setShowWarning] = useState(false);
+  const [isRevealed, setIsRevealed] = useState(false);
   const capsules = useStore((state) => state.capsules.created) || [];
   const navigateToCapsule = useNavigate();
-  
-  const nextCapsule = capsules
-    .filter((capsule) => capsule?.openAt)
-    .sort((a, b) => new Date(a.openAt).getTime() - new Date(b.openAt).getTime())
-    .find((capsule) => new Date(capsule.openAt) > new Date()) || null;
+
+  const nextCapsule = !isRevealed
+    ? capsules
+        .filter((capsule) => capsule?.openAt)
+        .sort((a, b) => new Date(a.openAt).getTime() - new Date(b.openAt).getTime())
+        .find((capsule) => new Date(capsule.openAt) > new Date()) || null
+    : null;
 
   const { capsuleId, isCapsuleOpen, timeLeft } = useCapsuleStatus(nextCapsule);
+
+  useEffect(() => {
+    if (!isCapsuleOpen || isRevealed) return;
+
+    // Stopps nextCapsule for 10 minutes
+    setIsRevealed(true);
+    const revealTimer = setTimeout(() => {
+      setIsRevealed(false);
+    }, 600000); // 10 minutes 
+
+    return () => clearTimeout(revealTimer);
+  }, [isCapsuleOpen, isRevealed]);
 
   const handlePlayButtonClick = () => {
     if (!capsuleId) return;
@@ -28,7 +44,7 @@ export const LatestLocket = () => {
     } else {
       setShowWarning(true);
     }
-  }
+  };
 
   return (
     <>

--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -2,14 +2,18 @@ import { useState, useEffect } from "react";
 import { ClockIcon } from "../ui/ClockIcon";
 import { PlayButton } from "../ui/PlayButton";
 import { CapsuleCardImage } from "../ui/CapsuleCardImage";
+import { WarningPopup } from "./WarningPopup";
 import useStore from "../store/store";
 import "./LatestLocket.css";
+import { useNavigate } from "react-router-dom";
 
 export const LatestLocket = () => {
   const [timeLeft, setTimeLeft] = useState(null);
   const [nextCapsule, setNextCapsule] = useState(null);
+  const [showWarning, setShowWarning] = useState(false);
 
   const capsules = useStore((state) => state.capsules.created);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (capsules.length === 0) {
@@ -17,8 +21,9 @@ export const LatestLocket = () => {
     }
 
     const sortedCapsules = capsules
-      .filter((capsule) => capsule.openAt)
+      .filter((capsule) => capsule?.openAt)
       .sort((a, b) => new Date(a.openAt) - new Date(b.openAt));
+    
     const nextCapsule = sortedCapsules.find(
       (capsule) => new Date(capsule.openAt) > new Date()
     );
@@ -49,7 +54,20 @@ export const LatestLocket = () => {
     return () => clearInterval(interval);
   }, [capsules]);
 
+  const isCapsuleOpen = nextCapsule && new Date(nextCapsule.openAt) <= new Date();
+
+  const handlePlayButtonClick = () => {
+    if (!nextCapsule) return;
+    
+    if (isCapsuleOpen) {
+      navigate(`/capsules/${nextCapsule.id}`);
+    } else {
+      setShowWarning(true);
+    }
+  };
+
   return (
+    <>
     <div className="latest-locket">
       <div className="locket-content">
         {nextCapsule ? (
@@ -65,7 +83,8 @@ export const LatestLocket = () => {
           <p className="countdown-text">No upcoming capsules</p>
         )}
       </div>
-      <PlayButton onClick={() => alert("Play Locket!")} />
+      <PlayButton onClick={handlePlayButtonClick} />
+
       <div className="locket-images">
         <CapsuleCardImage
           mediaUrls={["https://via.placeholder.com/150"]}
@@ -84,5 +103,7 @@ export const LatestLocket = () => {
         />
       </div>
     </div>
+    { showWarning && <WarningPopup onClose={() => setShowWarning(false)} /> }
+  </>
   );
 };

--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -65,7 +65,7 @@ export const LatestLocket = () => {
     <>
       <div className="latest-locket">
         
-        <LocketCountdown nextLocket={nextLocket} timeLeft={timeLeft} />
+      <LocketCountdown nextLocket={nextCapsule} timeLeft={timeLeft} />
 
         <PlayButton onClick={handlePlayButtonClick} />
 

--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -13,26 +13,30 @@ export const LatestLocket = () => {
   const [showWarning, setShowWarning] = useState(false);
 
   const capsules = useStore((state) => state.capsules.created);
-  const navigate = useNavigate();
+  const navigateToCapsule = useNavigate();
 
   useEffect(() => {
-    if (capsules.length === 0) {
-      return;
-    }
+    if (!Array.isArray(capsules) || capsules.length === 0) return;
 
     const sortedCapsules = capsules
       .filter((capsule) => capsule?.openAt)
       .sort((a, b) => new Date(a.openAt) - new Date(b.openAt));
     
-    const nextCapsule = sortedCapsules.find(
+    const upcomingCapsule = sortedCapsules.find(
       (capsule) => new Date(capsule.openAt) > new Date()
     );
 
-    if (!nextCapsule) {
-      return;
+    if (upcomingCapsule) {
+      setNextCapsule(upcomingCapsule);
     }
+  }, [capsules]);
 
-    setNextCapsule(nextCapsule);
+  // Get id and check if the capsule is open 
+  const capsuleId = nextCapsule?._id || nextCapsule.id;
+  const isCapsuleOpen = nextCapsule ? new Date() >= new Date(nextCapsule.openAt) : false;
+  
+  useEffect(() => {
+   if (!nextCapsule) return;
 
     const interval = setInterval(() => {
       const currentTime = new Date();
@@ -52,9 +56,7 @@ export const LatestLocket = () => {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [capsules]);
-
-  const isCapsuleOpen = nextCapsule && new Date(nextCapsule.openAt) <= new Date();
+  }, [nextCapsule]);
 
   const handlePlayButtonClick = () => {
     if (!nextCapsule) return;

--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo } from "react";
-import { ClockIcon } from "../ui/ClockIcon";
 import { PlayButton } from "../ui/PlayButton";
 import { CapsuleCardImage } from "../ui/CapsuleCardImage";
 import { WarningPopup } from "./WarningPopup"; 
@@ -7,6 +6,7 @@ import useStore from "../store/store";
 import "./LatestLocket.css";
 import { useNavigate } from "react-router-dom";
 import { useCapsuleStatus } from "../hooks/useCapsuleStatus";
+import { LocketCountdown } from "./LocketCountdown"; 
 
 export const LatestLocket = () => {
   const [nextCapsule, setNextCapsule] = useState(null);
@@ -64,22 +64,8 @@ export const LatestLocket = () => {
   return (
     <>
       <div className="latest-locket">
-        <div className="locket-content">
-          {/* If there is a capsule to open */}
-          {nextCapsule ? (
-            <>
-              <p>Your latest locket is opening on</p>
-              <div className="locket-date">
-                <ClockIcon />
-                <span>{new Date(nextCapsule.openAt).toLocaleString()}</span>
-              </div>
-              <p className="countdown-text">{timeLeft}</p>
-            </>
-          ) : (
-            // No more lockets
-            <p className="countdown-text">No upcoming lockets</p>
-          )}
-        </div>
+        
+        <LocketCountdown nextLocket={nextLocket} timeLeft={timeLeft} />
 
         <PlayButton onClick={handlePlayButtonClick} />
 

--- a/frontend/src/components/LocketCountdown.jsx
+++ b/frontend/src/components/LocketCountdown.jsx
@@ -1,0 +1,22 @@
+
+import { ClockIcon } from "../ui/ClockIcon";
+
+export const LocketCountdown = ({ nextLocket, timeLeft }) => {
+  return (
+    <div className="locket-content">
+      {nextLocket ? (
+        <>
+          <p>Your latest locket is opening on</p>
+          <div className="locket-date">
+            <ClockIcon />
+            <span>{new Date(nextLocket.openAt).toLocaleString()}</span>
+          </div>
+          <p className="countdown-text">{timeLeft}</p>
+        </>
+      ) : (
+        <p className="countdown-text">No upcoming lockets</p>
+      )}
+    </div>
+  );
+};
+

--- a/frontend/src/hooks/useCapsuleStatus.js
+++ b/frontend/src/hooks/useCapsuleStatus.js
@@ -1,10 +1,9 @@
 import { useState, useEffect } from "react";
 
 export const useCapsuleStatus = (capsule) => {
-  // Hooks måste alltid exekveras
+
   const [timeLeft, setTimeLeft] = useState(null);
 
-  // Säkerställ att capsuleId finns
   const capsuleId = capsule?._id || capsule?.id || null;
   const isCapsuleOpen = capsule ? new Date() >= new Date(capsule.openAt) : false;
 
@@ -18,7 +17,7 @@ export const useCapsuleStatus = (capsule) => {
 
       if (diff <= 0) {
         clearInterval(interval);
-        setTimeLeft("The capsule is now open!");
+        setTimeLeft("The locket is now open!");
       } else {
         const hours = Math.floor(diff / (1000 * 60 * 60));
         const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));

--- a/frontend/src/hooks/useCapsuleStatus.js
+++ b/frontend/src/hooks/useCapsuleStatus.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+
+export const useCapsuleStatus = (capsule) => {
+  const [timeLeft, setTimeLeft] = useState<string | null>(null);
+
+  if (!capsule) return { capsuleId: null, isCapsuleOpen: false, timeLeft };
+
+  const capsuleId = capsule._id || capsule.id;
+  const isCapsuleOpen = new Date() >= new Date(capsule.openAt);
+
+  useEffect(() => {
+    if (!capsule.openAt) return;
+
+    const interval = setInterval(() => {
+      const currentTime = new Date();
+      const targetTime = new Date(capsule.openAt);
+      const diff = targetTime.getTime() - currentTime.getTime();
+
+      if (diff <= 0) {
+        clearInterval(interval);
+        setTimeLeft("The capsule is now open!");
+      } else {
+        const hours = Math.floor(diff / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+        setTimeLeft(`${hours}h ${minutes}m ${seconds}s`);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [capsule]);
+
+  return { capsuleId, isCapsuleOpen, timeLeft };
+};

--- a/frontend/src/hooks/useCapsuleStatus.js
+++ b/frontend/src/hooks/useCapsuleStatus.js
@@ -1,20 +1,20 @@
 import { useState, useEffect } from "react";
 
 export const useCapsuleStatus = (capsule) => {
-  const [timeLeft, setTimeLeft] = useState<string | null>(null);
+  // Hooks måste alltid exekveras
+  const [timeLeft, setTimeLeft] = useState(null);
 
-  if (!capsule) return { capsuleId: null, isCapsuleOpen: false, timeLeft };
-
-  const capsuleId = capsule._id || capsule.id;
-  const isCapsuleOpen = new Date() >= new Date(capsule.openAt);
+  // Säkerställ att capsuleId finns
+  const capsuleId = capsule?._id || capsule?.id || null;
+  const isCapsuleOpen = capsule ? new Date() >= new Date(capsule.openAt) : false;
 
   useEffect(() => {
-    if (!capsule.openAt) return;
+    if (!capsule || !capsule.openAt) return;
 
     const interval = setInterval(() => {
       const currentTime = new Date();
       const targetTime = new Date(capsule.openAt);
-      const diff = targetTime.getTime() - currentTime.getTime();
+      const diff = targetTime - currentTime;
 
       if (diff <= 0) {
         clearInterval(interval);


### PR DESCRIPTION
### What has been done?
- Created a custom hook: useCapsuleStatus and added/moved the code that handles time left and capsule open status.
- Created LocketCountdown.jsx and added/moved the code that displays countdown and opening status.
- Added WarningPopup.jsx to show a warning message when trying to open a locked capsule.
- When a capsule opens, the message remains for 10 minutes before showing the next upcoming capsule.
- Filtered out only future capsules by checking openAt > now, and sorted capsules so that the next available locket is picked first. 
- Added useMemo to the filter and sorting to prevent unnecessary recalculations, ensuring filtering and sorting only happens when the capsule list (capsules) changes, not on every render.


### How to test 
1. Start the server: 
   ```bash
   cd backend
   npm run dev
   ```
2. Start the frontend: 
   ```bash
   cd frontend 
   npm run dev
   ```
3. Login and create a new capsule that opens within the next one or two minutes. 
4. Verify that the countdown works. 
5. Click on the Play button. A warning popup should be visible. 
6. Wait until the time has run out. You should see "The locket is now open!". 
7. Click on it and you should go to capsules/:id. 