### PR TITLE
Fix - Tilted images cut off

### DIFF
--- a/frontend/src/ui/CapsuleCardImage.css
+++ b/frontend/src/ui/CapsuleCardImage.css
@@ -3,7 +3,7 @@
   min-height: 100px;
   width: 140px;
   height: 140px;
-  overflow: hidden; 
+  overflow: visible;
   display: flex;
   justify-content: flex-start; 
   align-items: center;


### PR DESCRIPTION
### What has been done? 

Updated `overflow: hidden` to `overflow: visible` on `.capsule-card-image-container` to prevent the tilted images from being cut off.

Before: 
<img width="483" alt="Screenshot 2025-02-06 at 15 37 59" src="https://github.com/user-attachments/assets/3daf6b9d-4e36-4daa-8be5-40dede41c16e" />

After:
<img width="186" alt="Screenshot 2025-02-06 at 15 34 47" src="https://github.com/user-attachments/assets/6d282629-deed-4b54-ba5f-59192b0d5689" />
