### PR TITLE
Fix - Remove duplicate warning popup

### DIFF
--- a/frontend/src/components/LatestLocket.jsx
+++ b/frontend/src/components/LatestLocket.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { PlayButton } from "../ui/PlayButton";
 import { CapsuleCardImage } from "../ui/CapsuleCardImage";
 import { WarningPopup } from "./WarningPopup"; 
@@ -58,9 +58,11 @@ export const LatestLocket = () => {
     if (isCapsuleOpen) {
       navigateToCapsule(`/capsules/${capsuleId}`);
     } else {
+      if (!showWarning) {
       setShowWarning(true);
     }
-  };
+  }
+};
 
   return (
     <>

--- a/frontend/src/components/WarningPopup.jsx
+++ b/frontend/src/components/WarningPopup.jsx
@@ -23,7 +23,6 @@ export const WarningPopup = ({ onClose }) => {
         <p className="warning-text">
           Can’t open a locket <br /> before its release date.
         </p>
-        <p> TEST</p>
         <OkButton onClick={onClose} />
       </motion.div>
     </div>

--- a/frontend/src/components/WarningPopup.jsx
+++ b/frontend/src/components/WarningPopup.jsx
@@ -2,8 +2,14 @@ import "./WarningPopup.css";
 import warningIcon from "../assets/warningicon.png"; 
 import { OkButton } from "../ui/OkButton";
 import { motion } from "framer-motion";
+import { useEffect } from "react";
 
 export const WarningPopup = ({ onClose }) => {
+  useEffect(() => {
+    const img = new Image();
+    img.src = warningIcon;
+  }, []); 
+
   return (
     <div className="popup-overlay" role="alert">
       <motion.div 
@@ -17,6 +23,7 @@ export const WarningPopup = ({ onClose }) => {
         <p className="warning-text">
           Can’t open a locket <br /> before its release date.
         </p>
+        <p> TEST</p>
         <OkButton onClick={onClose} />
       </motion.div>
     </div>


### PR DESCRIPTION
### What has been done? 
The warningIcon had not fully loaded when the popup was first rendered, and to prevent unnecessary re-renders, this PR adds a preloading mechanism inside a useEffect hook within WarningPopup. This preloads the image as soon as the component mounts, allowing it to be cached before the popup is displayed.

```
 useEffect(() => {
   const img = new Image();
   img.src = warningIcon;
}, []);
```

### How to test: 
- Go to the dashboard, and ensure that you have an unlocked locket. 
- Click on the play button, and the popup should appear with a shake effect, but only once.
