### PR TITLE
Add styling to capsule-date to prevent default behavior on mobile.

### DIFF
--- a/frontend/src/components/CapsuleForm.css
+++ b/frontend/src/components/CapsuleForm.css
@@ -41,6 +41,7 @@
   box-sizing: border-box; /* Ensures consistent sizing */
 }
 
+
 .popup form textarea {
   height: 90px;
   resize: none; /* Prevent resizing */


### PR DESCRIPTION
### What has been done? 

Added specific styling to capsule-date to prevent default behavior on smaller screens.

### How to test: 
Since this issue is only on real devices, I guess the only test is to merge with main and reverse it if it doesn't work. 