### PR TITLE
Fix - Prevent default behavior for capsule-date on smaller screens 

### DIFF
--- a/frontend/src/components/CapsuleForm.css
+++ b/frontend/src/components/CapsuleForm.css
@@ -41,6 +41,13 @@
   box-sizing: border-box; /* Ensures consistent sizing */
 }
 
+/* Prevent device behavior */
+.popup form input[type="datetime-local"].capsule-date {
+  width: 90% !important; 
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
 
 .popup form textarea {
   height: 90px;


### PR DESCRIPTION
What has been done?
Added specific styling to capsule-date to prevent default behavior on smaller screens.

How to test:
Since this issue is only on real devices, I guess the only test is to merge with main and reverse it if it doesn't work.